### PR TITLE
Ignore Buildship generated files

### DIFF
--- a/Android/samples/.gitignore
+++ b/Android/samples/.gitignore
@@ -18,6 +18,10 @@ bin/
 gen/
 out/
 
+# Buildship files
+.project
+.settings/
+
 # Gradle files
 .gradle/
 build/


### PR DESCRIPTION
Ignores Buildship generated files (specific to Android samples)

### Description of the changes:
Adds new rules to Android/samples/.gitignore to ignore auto-generated .project file and .settings directory.